### PR TITLE
add kml overlay of chicago neighborhoods to map

### DIFF
--- a/app/assets/javascripts/maps.js
+++ b/app/assets/javascripts/maps.js
@@ -7,6 +7,9 @@ document.addEventListener('turbolinks:load', function(){
     markers = handler.addMarkers(locations);
     handler.bounds.extendWith(markers);
     handler.fitMapToBounds();
+    var kmls = handler.addKml(
+    { url: "https://data.cityofchicago.org/api/geospatial/bbvz-uum9?method=export&format=KML" }
+  );
   });
 
   if(document.querySelector(".tank_locations_new")){
@@ -39,13 +42,3 @@ function allowDropPin() {
     document.querySelector("#tank_location_longitude").value = location.lng
   });
 }
-
-
-
-
-
-
-
-
-
-


### PR DESCRIPTION
You don't need to merge this branch with master right now but thought it's something we can look into. I found these things called KML overlays which can be added to the map. I've added one that shows the boundaries of Chicago neighborhoods and if you click within a region it tells you the name of the neighborhood and some other details. I got the KML overlay from the [Chicago Data Portal](https://data.cityofchicago.org/Facilities-Geographic-Boundaries/Boundaries-Neighborhoods/bbvz-uum9/data).

It would be interesting if we could write some code that would look within each neighborhood boundary and add any water tanks within that boundary to a group, I'm thinking this would be a hash of sorts, maybe? Then within our index view we could have a dropdown list of neighborhoods so the user can display only water tanks in a certain neighborhood. 

I realize this goes beyond our original MVP requirements but thought it could be added to our list of stretch goals. Maybe something we can discuss on Thursday or Sunday.



![screenshot 2](https://user-images.githubusercontent.com/16002468/39790197-3bb13e84-52fa-11e8-9a9b-8ada5099a431.png)
![screenshot](https://user-images.githubusercontent.com/16002468/39790198-3bc752f0-52fa-11e8-94f9-67cfcf7e159d.png)
