### PR TITLE
change marker picture from tank icon to first tank location photo and…

### DIFF
--- a/app/controllers/tank_locations_controller.rb
+++ b/app/controllers/tank_locations_controller.rb
@@ -52,10 +52,11 @@ class TankLocationsController < ApplicationController
         @hash = Gmaps4rails.build_markers(locations) do |tank_location, marker|
           marker.lat tank_location.latitude
           marker.lng tank_location.longitude
+          marker.infowindow tank_location.address
           marker.picture({
-                    :url    => "https://image.ibb.co/iQugxS/water_tank_icon.png",
-                    :width  => "32",
-                    :height => "32"
+                    :url => tank_location.photos.first.image.url(:thumb),
+                    :width  => "75",
+                    :height => "100"
                    })
         end
     end

--- a/app/models/photo.rb
+++ b/app/models/photo.rb
@@ -3,7 +3,6 @@ class Photo < ApplicationRecord
   belongs_to :tank_location, optional: false
   belongs_to :user
 
-  has_attached_file :image, :styles => { :medium => "300x300>", :thumb => "100x100>" }, :default_url => "/images/:style/missing.png"
+  has_attached_file :image, :styles => { :medium => "300x300>", :thumb => "100x75" }, :default_url => "/images/:style/missing.png"
   validates_attachment_content_type :image, :content_type => /\Aimage\/.*\Z/
 end
-


### PR DESCRIPTION
I found the labels on the right so I'm calling this an enhancement. Again, you don't need to merge this pull request just yet. I wanted to use it as a discussion point more than anything. 

I've changed the marker picture to be the first image of each tank location. I was really trying to get the water tank image to show up inside the info window on click but I couldn't get that to work.

I don't really care for how the photos don't resize when you zoom out. I think the photos are too large and probably won't work once we have a lot of them on the map. Anyway, just some food for thought.

![screenshot 3](https://user-images.githubusercontent.com/16002468/39791793-1a280622-5303-11e8-9934-48ec9cc06339.png)
