### PR TITLE
tank location.photos sort by most upvotes

### DIFF
--- a/app/views/tank_locations/show.html.erb
+++ b/app/views/tank_locations/show.html.erb
@@ -4,13 +4,13 @@
 <h3><%= @tank_location.address %></h3>
 
 <div class="tank-location-photos-container">
-	<% @tank_location.photos.each do |photo| %>
+	<% @tank_location.photos.order(:cached_votes_up => :desc).each do |photo| %>
 	<div class="tank-image">
 		<%= image_tag photo.image.url(:medium) %>
 	</div>
 	<% if current_user %>
-		<%= link_to 'Up Vote', like_photo_path(photo), method: 'PUT' %> 
-		<%= link_to 'Down Vote', dislike_photo_path(photo), method: 'PUT' %> 
+		<%= link_to 'Up Vote', like_photo_path(photo), method: 'PUT' %>
+		<%= link_to 'Down Vote', dislike_photo_path(photo), method: 'PUT' %>
 	<% end  %>
 	<div class="votes">
 		<%= photo.get_upvotes.size %>

--- a/db/migrate/20180510211440_add_cached_votes_to_photos.rb
+++ b/db/migrate/20180510211440_add_cached_votes_to_photos.rb
@@ -1,0 +1,16 @@
+class AddCachedVotesToPhotos < ActiveRecord::Migration[5.1]
+  def change
+    change_table :photos do |t|
+        t.integer :cached_votes_total, default: 0
+        t.integer :cached_votes_score, default: 0
+        t.integer :cached_votes_up, default: 0
+        t.integer :cached_votes_down, default: 0
+        t.integer :cached_weighted_score, default: 0
+        t.integer :cached_weighted_total, default: 0
+        t.float :cached_weighted_average, default: 0.0
+    end
+
+        # Uncomment this line to force caching of existing votes
+         Photo.find_each(&:update_cached_votes)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180508183841) do
+ActiveRecord::Schema.define(version: 20180510211440) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -33,6 +33,13 @@ ActiveRecord::Schema.define(version: 20180508183841) do
     t.string "image_content_type"
     t.integer "image_file_size"
     t.datetime "image_updated_at"
+    t.integer "cached_votes_total", default: 0
+    t.integer "cached_votes_score", default: 0
+    t.integer "cached_votes_up", default: 0
+    t.integer "cached_votes_down", default: 0
+    t.integer "cached_weighted_score", default: 0
+    t.integer "cached_weighted_total", default: 0
+    t.float "cached_weighted_average", default: 0.0
   end
 
   create_table "tank_locations", force: :cascade do |t|


### PR DESCRIPTION
Hey I think we're good to go on this. I ran a migration to add the caching columns to the photos table - [info here](https://github.com/ryanto/acts_as_votable#caching). Then I added the sort to the view on the tank location show page. If you check the documentation we can choose to sort these in a number of ways, and truthfully I'm not sure of the intricacies of each sort but for now I've just sorted in descending order by most upvotes. 