### PR TITLE
style the add tank form

### DIFF
--- a/app/assets/stylesheets/addtank.scss
+++ b/app/assets/stylesheets/addtank.scss
@@ -34,6 +34,7 @@
           .fileContainer {
             overflow: hidden;
             position: relative;
+            margin-top: 1em;
           }
 
           .fileContainer [type=file] {

--- a/app/assets/stylesheets/addtank.scss
+++ b/app/assets/stylesheets/addtank.scss
@@ -1,0 +1,92 @@
+#map_tank {
+  padding: 5em 0;
+  text-align: center;
+  background: #2a2a2e;
+  .map_tank_inner {
+    width: 600px;
+    max-width: 90%;
+    margin: 0 auto;
+    #map-a-tank {
+    h2 {
+      font-size: 1.75em;
+      color: $white;
+    }
+    .map_tank_form {
+      #tank_location_address, #tank_location_neighborhood {
+        margin-top: 3em;
+
+          width: 48%;
+          margin: 1em .5%;
+          height: 3.25em;
+          border: none;
+          outline: none;
+          border-radius: .3em;
+          background: #404043;
+          padding: .5em 1.25em;
+          font-size: .8em;
+          color: $white;
+          }
+
+          #tank_location_neighborhood, #tank_location_address {
+            display: none;
+          }
+
+          .fileContainer {
+            overflow: hidden;
+            position: relative;
+          }
+
+          .fileContainer [type=file] {
+              cursor: inherit;
+              display: block;
+              font-size: 1px;
+              filter: alpha(opacity=0);
+              min-height: 100%;
+              min-width: 100%;
+              opacity: 0;
+              position: absolute;
+              right: 0;
+              text-align: right;
+              top: 0;
+          }
+
+          /* Example stylistic flourishes */
+
+          .fileContainer {
+              background: $highlight;
+              border-radius: 2em;
+              border: none;
+              outline: none;
+              padding: 0.8em 2em 0em 2em;
+              width: 300px;
+              i {
+                color: $white;
+              }
+              p {
+                color: $white;
+                font-weight: 700;
+                font-size: .9em;
+              }
+          }
+
+          .fileContainer [type=file] {
+              cursor: pointer;
+          }
+
+
+      .button {
+        border: none;
+        outline: none;
+        padding: 1em 4.5em;
+        border-radius: 2em;
+        background: $highlight;
+        color: $white;
+        font-weight: 700;
+        font-size: .9em;
+        margin-top: 1em;
+        width: 300px;
+        }
+      }
+    }
+  }
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -14,6 +14,7 @@
 @import 'bootstrap';
 @import 'maps';
 @import 'styles';
+@import 'addtank';
 
 .big-main-button {
   margin-bottom: 1%;

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -27,31 +27,3 @@
   background-size: cover;
   color: #ffffff;
 }
-
-/* footer */
-
-footer {
-  margin-top: 45px;
-  padding-top: 5px;
-  border-top: 1px solid #000000;
-  color: #000000;
-}
-
-footer a {
-    color: #000;
-}
-
-footer ul {
-    float: right;
-    list-style: none;
-}
-
-footer ul  li {
-      float: left;
-      margin-left: 15px;
-}
-
-
-footer small {
-  float: left;
-}

--- a/app/assets/stylesheets/styles.scss
+++ b/app/assets/stylesheets/styles.scss
@@ -259,6 +259,7 @@ h1, h2, h3, h4, h5, h6 {
 #main_footer {
   padding: 2.5em 0;
   text-align: center;
+  border-top: 1px solid $light_gray;
   .logo {
     text-transform: uppercase;
     font-size:1.15em;

--- a/app/assets/stylesheets/styles.scss
+++ b/app/assets/stylesheets/styles.scss
@@ -7,6 +7,8 @@ $off_white: #ececec;
 $red: #f85151;
 $gold: #fbc500;
 $dark_gold: #deae00;
+$dark_gray: #333333;
+$light_gray: #838383;
 
 * {
   box-sizing: border-box;

--- a/app/views/tank_locations/_form.html.erb
+++ b/app/views/tank_locations/_form.html.erb
@@ -1,45 +1,51 @@
-<div id="map-a-tank">
-  <%= form_for(@tank_location, local: true) do |form| %>
-   <% if tank_location.errors.any? %>
-     <div id="error_explanation">
-       <h2><%= pluralize(tank_location.errors.count, "error") %> prohibited this tank_location from being saved:</h2>
+<section id="map_tank">
+  <div class="map_tank_inner">
+    <div id="map-a-tank">
+      <div class="map_tank_form">
+        <%= form_for(@tank_location, local: true) do |form| %>
+         <% if tank_location.errors.any? %>
+           <div id="error_explanation">
+             <h2><%= pluralize(tank_location.errors.count, "error") %> prohibited this tank_location from being saved:</h2>
 
-       <ul>
-       <% tank_location.errors.full_messages.each do |message| %>
-         <li><%= message %></li>
-       <% end %>
-       </ul>
-     </div>
-   <% end %>
-    <h3>Enter the address for the tank or drop a pin on the map.</h3>
-   <div class="field form-group">
-     <%= form.text_field :latitude, id: :tank_location_latitude, class: 'form-control', type: 'hidden' %>
-   </div>
+             <ul>
+             <% tank_location.errors.full_messages.each do |message| %>
+               <li><%= message %></li>
+             <% end %>
+             </ul>
+           </div>
+         <% end %>
 
-   <div class="field form-group">
-     <%= form.text_field :longitude, id: :tank_location_longitude, class: 'form-control', type: 'hidden' %>
-   </div>
+            <h2>Click the map to add a water tank</h2>
+            <div>
+             <%= form.text_field :latitude, id: :tank_location_latitude, class: 'form-control', type: 'hidden' %>
+            </div>
 
-   <div class="field form-group">
-     <%= form.label :address %>
-     <%= form.text_field :address, id: :tank_location_address, class: 'form-control' %>
-   </div>
+            <div class="field form-group">
+             <%= form.text_field :longitude, id: :tank_location_longitude, class: 'form-control', type: 'hidden' %>
+            </div>
 
-    <div class="field form-group">
-     <%= form.label :neighborhood %>
-     <%= form.select :neighborhood, get_neighborhood_names, id: :tank_location_address, class: 'form-control' %>
-   </div>
+            <div>
+             <%= form.text_field :address, placeholder: 'Address', id: :tank_location_address %>
+            </div>
 
+            <div>
+             <%= form.select :neighborhood, get_neighborhood_names, id: :tank_location_neighborhood %>
+            </div>
 
-   <div class="field form-group">
-      <%= form.fields_for :photos do |photo_form| %>
-        <%= photo_form.label :image %>
-        <%= photo_form.file_field :image, id: :photo_image %>
-      <% end %>
-   </div>
+               <div>
+                  <%= form.fields_for :photos do |photo_form| %>
+                    <label class="fileContainer">
+                      <%= photo_form.file_field :image, id: :photo_image %>
+                      <i class="fa fa-camera"></i><p>Upload a Photo</p>
+                    </label>
+                  <% end %>
+               </div>
 
-   <div class="actions form-group">
-     <%= form.submit %>
-   </div>
-  <% end %>
-</div>
+               <div>
+                 <%= form.submit "Submit", class: "button" %>
+               </div>
+          <% end %>
+    </div>
+    </div>
+  </div>
+</section>

--- a/app/views/tank_locations/new.html.erb
+++ b/app/views/tank_locations/new.html.erb
@@ -1,3 +1,1 @@
-<h1>New Water Tank</h1>
-
 <%= render 'form', tank_location: @tank_location %>


### PR DESCRIPTION
I styled the add tank form to match the sign in / log in form styles.

A couple points we can discuss tomorrow:

- I hid the field for the address so the user only needs to click to add a marker. I like it because it cleans up the design but now you can't enter a address if you prefer that method. I'm open to displaying this field but wanted to see it hidden. 
- I hid the neighborhood dropdown field. Since this data is determined based on the pin drop I've hidden this and we can display the neighborhood info in some interesting ways on the index and show pages.
- Styling the file field button was very challenging and the current way isn't perfect in that after you upload an image there is no messaging for the user to know they have successfully attached an image until they then click the submit button and see their new tank location created with their photo.

Anyway, there's a lot of ways we can tweak this but wanted to give you this version that we can discuss tomorrow.

